### PR TITLE
input-reset for input type="number"

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -14,6 +14,15 @@
 .input-reset {
   -webkit-appearance: none;
   -moz-appearance: none;
+
+  &[type="number"] {
+    -moz-appearance: textfield;
+
+    &::-webkit-inner-spin-button, &::-webkit-outer-spin-button { 
+      -webkit-appearance: none;
+      margin: 0; 
+    }
+  }
 }
 
 .button-reset::-moz-focus-inner,


### PR DESCRIPTION
fix: number inputs with input-reset should not show arrows